### PR TITLE
Migrate jail polyzone to vorp_lib PolyZones module, removing external…

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,8 +12,6 @@ shared_scripts {
 }
 
 client_scripts {
-    '@PolyZone/client.lua',
-    '@PolyZone/CircleZone.lua',
     'client/main.lua',
 }
 
@@ -26,10 +24,6 @@ server_scripts {
 files {
     'languages/translation.lua',
     'configs/config.lua',
-}
-
-dependencies {
-    "PolyZone"
 }
 
 version '0.6'

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ This script requires the following VORP resources to function properly:
 - **[VORP Core](https://github.com/VORPCORE/vorp_core-lua)**: Provides essential functions and event handlers used throughout the script.
 - **[VORP Inventory](https://github.com/VORPCORE/vorp_inventory-lua)**: Manages the item-based inventory system, including cuffs and keys.
 - **[VORP Menu](https://github.com/VORPCore/vorp_menu)**: Powers the interactive menu system, used for the boss menu, hire/fire system, and teleportation points.
-- **[PolyZone](https://github.com/outsider31000/PolyZone)**: download polyzone
+- **[VORP Lib](https://github.com/VORPCORE/vorp_lib)**: Supplies shared utilities, including the PolyZones module now used for jail boundaries.
 
 Ensure you have these resources installed and correctly set up for the `vorp_police` script to work seamlessly.
 

--- a/version
+++ b/version
@@ -2,7 +2,6 @@
 - added vorp_lib support
 - added vorp_menu features to the menus
 - small fixes and features
-- migrated jail polyzone to vorp_lib PolyZones module (no external PolyZone dependency)
 <0.5>
 - fix jail system
 - added config to allow everyone use cuffs or only police

--- a/version
+++ b/version
@@ -2,6 +2,7 @@
 - added vorp_lib support
 - added vorp_menu features to the menus
 - small fixes and features
+- migrated jail polyzone to vorp_lib PolyZones module (no external PolyZone dependency)
 <0.5>
 - fix jail system
 - added config to allow everyone use cuffs or only police


### PR DESCRIPTION
Update **vorp_police** to use **PolyZones** from **vorp_lib** instead of the standalone version.
